### PR TITLE
Add React and React-Bootstrap as dependencies in package.json

### DIFF
--- a/src/COCOA/wwwroot/package.json
+++ b/src/COCOA/wwwroot/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "devDependencies": {},
   "dependencies": {
-    "react-bootstrap": "^0.30.7"
+    "react": "^15.4.2",
+    "react-bootstrap": "^0.30.7",
+    "react-dom": "^15.4.2"
   }
 }


### PR DESCRIPTION
Makes installing the npm packages a little more streamlined