### PR TITLE
Added link on header to DocumentUpload page

### DIFF
--- a/src/COCOA/Controllers/CourseController.cs
+++ b/src/COCOA/Controllers/CourseController.cs
@@ -128,7 +128,7 @@ namespace COCOA.Controllers
                 return StatusCode(400, resultShared);
             }
 
-            return View("DocumentSearch", model);
+            return View("DocumentUpload", model);
         }
 
         /// <summary>

--- a/src/COCOA/wwwroot/js/components/CocoaHeader.jsx
+++ b/src/COCOA/wwwroot/js/components/CocoaHeader.jsx
@@ -39,6 +39,7 @@ class CocoaHeader extends React.Component {
                     </NavDropdown>
                     {this.props.signedIn && (<NavItem eventKey={"4"} href='/course/materialsearch'>Document search</NavItem>)}
                     {this.props.signedIn && (<NavItem eventKey={"5"} href='/course/enrollment'>Enroll to course</NavItem>)}
+                    {this.props.assignedCourses.length != 0 && (<NavItem eventKey={"6"} href='/course/documentupload'>Upload document</NavItem>)}
                     </Nav>
                     <Nav pullRight>
                     {!this.props.signedIn && (<NavItem eventKey={1} href='/user/signin'>Log in</NavItem>)}


### PR DESCRIPTION
Only available to those who are assigned to courses

Also, this fixes the bug of /courses/documentupload redirecting to documentsearch